### PR TITLE
Send log with sub properties (dictionary) mapped

### DIFF
--- a/sample/Serilog.Sinks.NewRelicLogs.Sample/Program.cs
+++ b/sample/Serilog.Sinks.NewRelicLogs.Sample/Program.cs
@@ -38,10 +38,10 @@ namespace Serilog.Sinks.NewRelicLogs.Sample
 
             // Adding a custom transaction
 
-            using (Log.Logger.BeginTimedOperation("Time a thread sleep for 2 seconds."))
+            using (logger.BeginTimedOperation("Time a thread sleep for 2 seconds."))
             {
                 Thread.Sleep(1000);
-                using (Log.Logger.BeginTimedOperation("And inside we try a Task.Delay for 2 seconds."))
+                using (logger.BeginTimedOperation("And inside we try a Task.Delay for 2 seconds."))
                 {
                     Task.Delay(2000).Wait();
                 }

--- a/sample/Serilog.Sinks.NewRelicLogs.Sample/Program.cs
+++ b/sample/Serilog.Sinks.NewRelicLogs.Sample/Program.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using NewRelic.LogEnrichers.Serilog;
+using Serilog.Context;
+using Serilog.Events;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NewRelic.LogEnrichers.Serilog;
-using Serilog.Events;
 
 namespace Serilog.Sinks.NewRelicLogs.Sample
 {
@@ -22,12 +23,13 @@ namespace Serilog.Sinks.NewRelicLogs.Sample
                 .Enrich.WithMachineName()
                 .Enrich.WithThreadId()
                 .Enrich.WithNewRelicLogsInContext()
+                .Enrich.FromLogContext()
                 .CreateLogger();
-            
+
             logger
                 .ForContext("SampleTransaction", "trans1")
                 .Information("Message in a transaction");
-
+               
             const string template = "This is a simple {Level} message {Val}";
             logger.Verbose(template, LogEventLevel.Verbose, (int)LogEventLevel.Verbose);
             logger.Debug(template, LogEventLevel.Debug, (int)LogEventLevel.Debug);
@@ -36,10 +38,10 @@ namespace Serilog.Sinks.NewRelicLogs.Sample
 
             // Adding a custom transaction
 
-            using (logger.BeginTimedOperation("Time a thread sleep for 2 seconds."))
+            using (Log.Logger.BeginTimedOperation("Time a thread sleep for 2 seconds."))
             {
                 Thread.Sleep(1000);
-                using (logger.BeginTimedOperation("And inside we try a Task.Delay for 2 seconds."))
+                using (Log.Logger.BeginTimedOperation("And inside we try a Task.Delay for 2 seconds."))
                 {
                     Task.Delay(2000).Wait();
                 }
@@ -92,11 +94,35 @@ namespace Serilog.Sinks.NewRelicLogs.Sample
             {
                 logger.Error(ex, "Error whilst testing the Serilog.Sinks.NewRelicLogs.Sample");
                 logger.Error("A templated test message notifying of an error. Value {val}", 1);
+
+                // adding complex object
+                LogContext.PushProperty("ComplexDictionary", GetComplexDictionary());
+                logger.Error("Test with complex object and dictionary");
             }
 
             logger.Dispose();
+
             Console.WriteLine("Press a key to exit.");
             Console.ReadKey(true);
+        }
+
+        public static IDictionary<string, object> GetComplexDictionary()
+        {
+            return new Dictionary<string, object>
+            {
+                {
+                    "property1", "WORKS!"
+                },
+                {
+                    "property2", 123
+                },
+                {
+                    "property3", new Dictionary<string, object>
+                    {
+                        { "subpropertie", "blah blah" }
+                    }
+                }
+            };
         }
     }
 }

--- a/src/Serilog.Sinks.NewRelicLogs/Serilog.Sinks.NewRelicLogs.csproj
+++ b/src/Serilog.Sinks.NewRelicLogs/Serilog.Sinks.NewRelicLogs.csproj
@@ -50,7 +50,9 @@
   <ItemGroup>
     <Compile Include="NewRelicLoggerConfigurationExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Sinks\NewRelicLogs\NewRelicLogPayload.cs" />
     <Compile Include="Sinks\NewRelicLogs\NewRelicLogsSink.cs" />
+    <Compile Include="Sinks\NewRelicLogs\NewRelicPropertyFormatter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/src/Serilog.Sinks.NewRelicLogs/Sinks/NewRelicLogs/NewRelicLogPayload.cs
+++ b/src/Serilog.Sinks.NewRelicLogs/Sinks/NewRelicLogs/NewRelicLogPayload.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Serilog.Sinks.NewRelicLogs
+{
+    public class NewRelicLogPayload
+    {
+        public NewRelicLogCommon common { get; set; } = new NewRelicLogCommon();
+
+        public IList<NewRelicLogItem> logs { get; set; } = new List<NewRelicLogItem>();
+    }
+
+    public class NewRelicLogCommon
+    {
+        public IDictionary<string, object> attributes { get; set; } = new Dictionary<string, object>();
+    }
+
+    public class NewRelicLogItem
+    {
+        public long timestamp { get; set; }
+
+        public string message { get; set; }
+
+        public IDictionary<string, object> attributes { get; set; } = new Dictionary<string, object>();
+    }
+}

--- a/src/Serilog.Sinks.NewRelicLogs/Sinks/NewRelicLogs/NewRelicPropertyFormatter.cs
+++ b/src/Serilog.Sinks.NewRelicLogs/Sinks/NewRelicLogs/NewRelicPropertyFormatter.cs
@@ -1,0 +1,87 @@
+﻿using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Serilog.Sinks.NewRelicLogs
+{
+    public static class NewRelicPropertyFormatter
+    {
+        private static readonly HashSet<Type> LogScalars = new HashSet<Type>
+        {
+            typeof (bool),
+            typeof (byte),
+            typeof (short),
+            typeof (ushort),
+            typeof (int),
+            typeof (uint),
+            typeof (long),
+            typeof (ulong),
+            typeof (float),
+            typeof (double),
+            typeof (decimal),
+            typeof (byte[])
+        };
+
+        public static object Simplify(LogEventPropertyValue value)
+        {
+            var scalar = value as ScalarValue;
+            if (scalar != null)
+            {
+                return SimplifyScalar(scalar.Value);
+            }
+
+            var dict = value as DictionaryValue;
+            if (dict != null)
+            {
+                var result = new Dictionary<object, object>();
+                foreach (var element in dict.Elements)
+                {
+                    var key = SimplifyScalar(element.Key.Value);
+                    if (result.ContainsKey(key))
+                    {
+                        Trace.WriteLine(
+                            $"The key {element.Key} is not unique in the provided dictionary after simplification to {key}.");
+                        return dict.Elements.Select(e => new Dictionary<string, object>
+                        {
+                            {"Key", SimplifyScalar(e.Key.Value)},
+                            {"Value", Simplify(e.Value)}
+                        }).ToArray();
+                    }
+                    result.Add(key, Simplify(element.Value));
+                }
+                return result;
+            }
+
+            var seq = value as SequenceValue;
+            if (seq != null)
+            {
+                return seq.Elements.Select(Simplify).ToArray();
+            }
+
+            var str = value as StructureValue;
+            if (str != null)
+            {
+                var props = str.Properties.ToDictionary(p => p.Name, p => Simplify(p.Value));
+                if (str.TypeTag != null)
+                {
+                    props["$typeTag"] = str.TypeTag;
+                }
+                return props;
+            }
+
+            return null;
+        }
+
+        private static object SimplifyScalar(object value)
+        {
+            if (value == null) return null;
+
+            var valueType = value.GetType();
+            if (LogScalars.Contains(valueType)) return value;
+
+            return value.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Hello! First of all, thanks for new relic logs sink!

I was trying to use your sink, but for complex objects (nested dictionary) it don't works, the value is always logged as string.

See my tries:

![image](https://user-images.githubusercontent.com/12145276/82742437-7ed57500-9d34-11ea-885f-91b15713c132.png)

## Current behavior

Content sended to new relic API:

![image](https://user-images.githubusercontent.com/12145276/82742443-93197200-9d34-11ea-9904-bb589c9fbb05.png)

Event in NewRelic Logs dashboard:

![image](https://user-images.githubusercontent.com/12145276/82742466-f1465500-9d34-11ea-8fe3-279b8374eaa0.png)

Trying search for sub property:

![image](https://user-images.githubusercontent.com/12145276/82742473-0622e880-9d35-11ea-8923-762d9f517783.png)

## New behavior (after my PR)

Content sended to new relic API:

![image](https://user-images.githubusercontent.com/12145276/82742480-13d86e00-9d35-11ea-8257-594cfd8636b7.png)

Event in NewRelic Logs dashboard:

![image](https://user-images.githubusercontent.com/12145276/82742494-5a2dcd00-9d35-11ea-87be-cdb63845c0d8.png)

Trying search for sub property:

![image](https://user-images.githubusercontent.com/12145276/82742496-62860800-9d35-11ea-8737-7250230f4fe7.png)

## Feedback

Please, let me know if I need change something in my pull request and, if it's all fine, when a new version will be released.

Thank you!